### PR TITLE
feat: add module log category

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPModule.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPModule.cpp
@@ -4,18 +4,20 @@
 #include "EditorSubsystem.h"
 #include "Editor.h"
 
+DEFINE_LOG_CATEGORY(LogUnrealMCP);
+
 #define LOCTEXT_NAMESPACE "FUnrealMCPModule"
 
 void FUnrealMCPModule::StartupModule()
 {
-	UE_LOG(LogTemp, Display, TEXT("Unreal MCP Module has started"));
+       UE_LOG(LogUnrealMCP, Display, TEXT("Unreal MCP Module has started"));
 }
 
 void FUnrealMCPModule::ShutdownModule()
 {
-	UE_LOG(LogTemp, Display, TEXT("Unreal MCP Module has shut down"));
+       UE_LOG(LogUnrealMCP, Display, TEXT("Unreal MCP Module has shut down"));
 }
 
 #undef LOCTEXT_NAMESPACE
 	
-IMPLEMENT_MODULE(FUnrealMCPModule, UnrealMCP) 
+IMPLEMENT_MODULE(FUnrealMCPModule, UnrealMCP)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/UnrealMCPModule.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/UnrealMCPModule.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogUnrealMCP, Log, All);
+
 class FUnrealMCPModule : public IModuleInterface
 {
 public:
@@ -15,8 +17,8 @@ public:
 		return FModuleManager::LoadModuleChecked<FUnrealMCPModule>("UnrealMCP");
 	}
 
-	static inline bool IsAvailable()
-	{
-		return FModuleManager::Get().IsModuleLoaded("UnrealMCP");
-	}
-}; 
+        static inline bool IsAvailable()
+        {
+                return FModuleManager::Get().IsModuleLoaded("UnrealMCP");
+        }
+};


### PR DESCRIPTION
## Summary
- create `LogUnrealMCP` logging category for the plugin
- switch module startup/shutdown messages to new log category
- ensure module files end with newlines

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9b56cc348331b7c5ec45e83bef32